### PR TITLE
fix respond to latest twilio-ruby. Twilio::TwiML::Response already removed.

### DIFF
--- a/fluent-plugin-twilio.gemspec
+++ b/fluent-plugin-twilio.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit", ">= 3.1.0"
   s.add_runtime_dependency "fluentd", ">= 0.14.15", "< 2"
-  s.add_runtime_dependency "twilio-ruby"
+  s.add_runtime_dependency "twilio-ruby", "~> 5.5.0"
 end

--- a/lib/fluent/plugin/out_twilio.rb
+++ b/lib/fluent/plugin/out_twilio.rb
@@ -29,18 +29,18 @@ class Fluent::Plugin::TwilioOutput < Fluent::Plugin::Output
   end
 
   def call(number, message)
-    response = Twilio::TwiML::Response.new do |r|
-      r.Say message, voice: @voice, language: @language
+    response = Twilio::TwiML::VoiceResponse.new do |r|
+      r.say(message, voice: @voice, language: @language)
     end
-    xml = response.text.sub(/<[^>]+?>/, '')
+    xml = response.to_s.sub(/<[^>]+?>/, '')
     url = "http://twimlets.com/echo?Twiml=#{URI.escape(xml)}"
     log.info "twilio: generateing twiml: #{xml}"
 
     client = Twilio::REST::Client.new(@account_sid, @auth_token)
-    account = client.account
+    account = client.api.account
     number.gsub(' ', '').split(',').each do |to_number|
       begin
-        account.calls.create({from: @from_number, to: to_number, url: url})
+        account.calls.create(from: @from_number, to: to_number, url: url)
       rescue => e
         log.error "twilio: Error: #{e.message}"
       end


### PR DESCRIPTION
Hello.

twilio-ruby is already removed Twilio::TwiML::Response.
I respond latest twilio-ruby.

Changed class Twilio::TwiML::Response to Twilio::TwiML::VoiceResponse.
fixed twilio-ruby version is '~> 5.5.0'.