### PR TITLE
add default_message option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ fluent_logger.post('notify.call', {
   # Set defaults of making outbound call.
   # To call multiple phone at the same time, list them with comma like below.
   default_number  +819012345678,+818012345678  # Optional
+  default_message "call from fluentd."         # Optional
 
   # Set log level to prevent info error
   @log_level       warn

--- a/lib/fluent/plugin/out_twilio.rb
+++ b/lib/fluent/plugin/out_twilio.rb
@@ -11,6 +11,7 @@ class Fluent::Plugin::TwilioOutput < Fluent::Plugin::Output
   config_param :from_number, :string, default: ''
   config_param :default_number, :string, default: ''
   config_param :default_voice, :string, default: 'woman'
+  config_param :default_message, :string, default: nil
   config_param :language, :string, default: 'ja-jp'
 
   VOICE_MAP = ['man', 'woman']
@@ -24,7 +25,8 @@ class Fluent::Plugin::TwilioOutput < Fluent::Plugin::Output
     es.each do |time,record|
       number = record['number'].nil? ? @default_number : record['number']
       @voice = VOICE_MAP.include?(record['voice']) ? record['voice'] : @default_voice
-      call(number, record['message'])
+      message = record['message'] || @default_message
+      call(number, message)
     end
   end
 

--- a/test/plugin/test_out_twilio.rb
+++ b/test/plugin/test_out_twilio.rb
@@ -20,26 +20,30 @@ class TwilioOutputTest < Test::Unit::TestCase
       d = create_driver('')
     }
     d = create_driver %[
-      account_sid  TWILIO_ACCOUNT_SID
-      auth_token   TWILIO_AUTH_TOKEN
-      from_number  +8112345678
+      account_sid     TWILIO_ACCOUNT_SID
+      auth_token      TWILIO_AUTH_TOKEN
+      from_number     +8112345678
+      default_message test_message
     ]
     assert_equal 'TWILIO_ACCOUNT_SID', d.instance.account_sid
     assert_equal 'TWILIO_AUTH_TOKEN', d.instance.auth_token
     assert_equal '+8112345678', d.instance.from_number
+    assert_equal 'test_message', d.instance.default_message
   end
 
   def test_configure_multinumber
     d = create_driver %[
-      account_sid  TWILIO_ACCOUNT_SID
-      auth_token   TWILIO_AUTH_TOKEN
-      from_number  +8112345678
+      account_sid     TWILIO_ACCOUNT_SID
+      auth_token      TWILIO_AUTH_TOKEN
+      from_number     +8112345678
       default_number  +81123456789,+811234567890
+      default_message test_message
     ]
     assert_equal 'TWILIO_ACCOUNT_SID', d.instance.account_sid
     assert_equal 'TWILIO_AUTH_TOKEN', d.instance.auth_token
     assert_equal '+8112345678', d.instance.from_number
     assert_equal '+81123456789,+811234567890', d.instance.default_number
+    assert_equal 'test_message', d.instance.default_message
   end
 
 


### PR DESCRIPTION
Hello.

Sorry for the continuous ;;
We use case is record['message'] is nil.
This case call twilio too.


